### PR TITLE
Implemented items being pulled toward player.

### DIFF
--- a/Assets/Prefabs/Characters/Player.prefab
+++ b/Assets/Prefabs/Characters/Player.prefab
@@ -16,6 +16,7 @@ GameObject:
   - component: {fileID: 548689562930659569}
   - component: {fileID: 548689562930659582}
   - component: {fileID: 548689562930659571}
+  - component: {fileID: 1732815361}
   m_Layer: 8
   m_Name: Player
   m_TagString: Player
@@ -219,6 +220,21 @@ MonoBehaviour:
   _inventoryTool:
     _stacksCapacityResource: 9
     _sortType: 1
+--- !u!114 &1732815361
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 548689562930659578}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 910fb477aa5dd844ba837784a1a9eeb0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _attractionForce: 10
+  _maxAttractionSpeed: 32
+  _HomingPower: 0.75
 --- !u!1 &548689563490798967
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -253,6 +253,7 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+  _selectivelyListenTo: {fileID: 0}
 --- !u!114 &69169096
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -284,6 +285,7 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+  _selectivelyListenTo: {fileID: 0}
 --- !u!114 &69169097
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scriptable Objects/Items/BerryData.asset
+++ b/Assets/Scriptable Objects/Items/BerryData.asset
@@ -20,6 +20,7 @@ MonoBehaviour:
   _maxStack: 99
   _isDroppable: 1
   _isStackable: 1
+  _collectionRadius: 0
   _sortType: 2
   _saturationValue: 5
   <Attributes>k__BackingField: 

--- a/Assets/Scripts/Item/ItemAttractor.cs
+++ b/Assets/Scripts/Item/ItemAttractor.cs
@@ -1,0 +1,173 @@
+using Player;
+using System.Collections;
+using System.Collections.Generic;
+
+using UnityEngine;
+
+
+/// <summary>
+/// Place this class on a GameObject to make it attract items.
+/// </summary>
+/// <remarks>
+/// NOTE: You can make an item ignore item attractors. To do so, go to its ScriptableObject (ItemBase) and set the AttractionRadius property to 0.
+/// </remarks>
+public class ItemAttractor : MonoBehaviour
+{
+    [Tooltip("This property controls how strongly the item is pulled in.")]
+    [Range(0.1f, 100f)]
+    [SerializeField]
+    private float _attractionForce = 10f;
+
+    [Tooltip("This is the maximum speed an item is allowed to move at while being pulled in.")]
+    [Range(10f, 100f)]
+    [SerializeField]
+    private float _maxAttractionSpeed = 20f;
+
+    [Tooltip("This controls how well items will home in on the player. NOTE: Increasing the attraction speed of an item will also make it home in better since it'll just reach the attractor that much sooner.")]
+    [Range(0f, 1f)]
+    [SerializeField]
+    private float _HomingPower = 0.75f;
+
+
+    private Collider _collider;
+
+    private List<PickupItem> _itemsBeingAttracted = new List<PickupItem>();
+
+    // This is how frequently CheckForNewNearbyTargets() gets called.
+    private float _itemDetectionFrequency = 1f;
+
+    private float _homingStrength;
+
+    private float _itemDetectionTimer;
+
+
+    private InventoryScene _inventoryScene;
+
+
+
+    private void Awake()
+    {
+        _collider = GetComponent<Collider>();
+
+        // Get a reference to this object's InventoryScene or InventoryBase component. This script will use whichever is available.
+        _inventoryScene = GetComponent<InventoryScene>();
+
+        _homingStrength = _maxAttractionSpeed * (1f - _HomingPower);
+    }
+
+
+    // Update is called once per frame
+    void Update()
+    {
+        _itemDetectionTimer += Time.deltaTime;
+        if (_itemDetectionTimer >= _itemDetectionFrequency)
+        {
+            _itemDetectionTimer = 0;
+            CheckForNewNearbyItems();
+        }
+    }
+
+    private void FixedUpdate()
+    {
+        PullItems();
+    }
+
+    private void CheckForNewNearbyItems()
+    {
+        // We use MAX_ATTRACTION_RADIUS so any item within the max radius can be detected.
+        // Whether it actually starts getting pulled to this attractor depends on how far away it actually is.
+        Collider[] colliders = Physics.OverlapSphere(transform.position, ItemBase.MAX_ATTRACTION_RADIUS);
+        foreach (Collider c in colliders)
+        {
+            PickupItem item = c.GetComponent<PickupItem>();
+            if (item != null)
+            {
+                if (!_itemsBeingAttracted.Contains(item) &&
+                    InventoryHasRoomFor(new ItemStack(item.ItemInfo, item.Amount)))
+                {
+                    _itemsBeingAttracted.Add(item);
+                }
+            }
+
+        } // end foreach
+
+    }
+
+    /// <summary>
+    /// Checks if there is enough room for the specified item stack in this GameObject's inventory.
+    /// For now, this only supports the player's InventoryScene component. It could be expanded later if needed.
+    /// </summary>
+    /// <param name="item">The item stack to check if there is enough room for.</param>
+    /// <returns>True if there is enough room for the passed in item stack.</returns>
+    private bool InventoryHasRoomFor(ItemStack item)
+    {
+        if (_inventoryScene != null)
+        {
+            return _inventoryScene.GoIntoFirst.HasRoomForItem(item, true);
+        }
+
+
+        return false;
+    }
+
+    /// <summary>
+    /// This function checks all items that are being pulled into the player.
+    /// If an item is null (meaning it was collected by the player and destroyed)
+    /// then this function will simply remove it from the list.
+    /// </summary>
+    private void PullItems()
+    {
+        for (int i = _itemsBeingAttracted.Count - 1; i >= 0; i--) 
+        {
+            PickupItem item = _itemsBeingAttracted[i];
+            if (item == null) // If it's null, it means the player collected it.
+            {
+                _itemsBeingAttracted.RemoveAt(i);
+            }
+            else
+            { 
+                float itemDistance = Vector3.Distance(transform.position, item.transform.position);
+                if (itemDistance <= item.ItemInfo.AttractionRadius &&
+                    _inventoryScene.GoIntoFirst.HasRoomForItem(item, true))
+                {
+                    // I made a function call here so we can easily swap out this logic by calling a different function to change the attraction style.
+                    AttractItemNatural(item);
+                }
+                else
+                {
+                    // The item is too far away now, so remove it from the list so we stop pulling on it.
+                    _itemsBeingAttracted.RemoveAt(i--);
+                }
+            }
+            
+        } // end foreach
+    }
+
+    /// <summary>
+    /// This function pulls the item straight toward the player. It is the most basic way to do it.
+    /// </summary>
+    /// <param name="item">The item to attract.</param>
+    private void AttractItemLinear(PickupItem item)
+    {
+        // Get the direction from the item to this attractor.
+        Vector3 direction = (transform.position - item.transform.position).normalized; 
+
+        item.Rigidbody.velocity = direction * _attractionForce;
+    }
+
+    /// <summary>
+    /// This function pulls the item towards the player, but makes it look like the object has more momentum so it doesn't turn as sharply.
+    /// </summary>
+    /// <param name="item">The item to attract.</param>
+    private void AttractItemNatural(PickupItem item)
+    {
+        // Get the direction from the item to this attractor.
+        Vector3 direction = (transform.position - item.transform.position).normalized;
+        direction = item.Rigidbody.velocity + (direction * _attractionForce) / _homingStrength; // This division just slows down how quickly the item homes in on the player. A higher _attractionForce value will also make it appear to home in better.
+
+        // If speed is greator than max, then set it to max.
+        direction = direction.magnitude <= _maxAttractionSpeed ? direction : (direction.normalized * _maxAttractionSpeed);
+
+        item.Rigidbody.velocity = direction;
+    }
+}

--- a/Assets/Scripts/Item/ItemAttractor.cs.meta
+++ b/Assets/Scripts/Item/ItemAttractor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 910fb477aa5dd844ba837784a1a9eeb0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Item/ItemBase.cs
+++ b/Assets/Scripts/Item/ItemBase.cs
@@ -7,6 +7,12 @@ using UnityEngine;
 /// </summary>
 public abstract class ItemBase:ScriptableObject
 {
+    // This is the maximum distance any item can be pulled into the player from.
+    // It is also the search range used by the ItemAttraction.cs script.
+    public const float MAX_ATTRACTION_RADIUS = 50f;
+
+
+
     [SerializeField] private int _id;
     [SerializeField] private string _name;
     [SerializeField] private Sprite _icon;
@@ -14,13 +20,22 @@ public abstract class ItemBase:ScriptableObject
     [SerializeField] private int _maxStack;
     [SerializeField] private bool _isDroppable;
     [SerializeField] private bool _isStackable;
+
+
+    [Tooltip("This sets how close the player has to get before the item is pulled toward him. Set this value to 0 to make the item be unaffected by the player or any other object that has an ItemAttractor script on it.")]
+    [Range(0f, MAX_ATTRACTION_RADIUS)]
+    [SerializeField] private float _collectionRadius = 0f; // How close the player must get before the item is pulled to the player.
     
+
     [SerializeField] private ItemSortType _sortType;
 
     [SerializeField, Tooltip("Saturation value to be added to jelly after feeding")] 
     private int _saturationValue = 5;
+    
     [field: SerializeField]
     public List<ItemAttribute> Attributes { get; private set; }
+
+
 
     public enum ItemSortType
     { 
@@ -29,6 +44,7 @@ public abstract class ItemBase:ScriptableObject
         JellyItem,
         Resource
     }
+
 
     public int ID { get => _id; private set => _id = value; }
     public string Name { get => _name; private set => _name = value; }
@@ -39,6 +55,8 @@ public abstract class ItemBase:ScriptableObject
     public bool IsStackable { get => _isStackable; private set => _isStackable = value; }
     public ItemSortType SortType { get => _sortType; private set => _sortType = value; }
     public int SaturationValue { get => _saturationValue; private set => _saturationValue = value; }
+    public float AttractionRadius { get => _collectionRadius; private set => _collectionRadius = value; }
+
 
     public virtual void OnItemEquipped() { }
     public virtual void OnItemUnequip() { }

--- a/Assets/Scripts/Item/PickupItem.cs
+++ b/Assets/Scripts/Item/PickupItem.cs
@@ -13,16 +13,28 @@ public class PickupItem : MonoBehaviour
     [SerializeField]
     private int _amount = 1;
 
-    public ItemBase ItemInfo => _itemInfo;
+
+    private Rigidbody _rigidbody;
+
+
+    private void OnEnable()
+    {
+        if (_rigidbody == null)
+            _rigidbody = GetComponent<Rigidbody>();
+    }
 
     private void OnTriggerEnter(Collider other)
     {
         if (other.gameObject.TryGetComponent(out Player.InventoryScene inventoryAndHotBar))
         {
-            if(inventoryAndHotBar.GoIntoFirst.TryAddItem(new ItemStack(_itemInfo, _amount)))
+            if (inventoryAndHotBar.GoIntoFirst.TryAddItem(new ItemStack(_itemInfo, _amount)))
             {
                 Destroy(gameObject);
             }
         }
     }
+
+    public int Amount { get => _amount; }
+    public ItemBase ItemInfo { get => _itemInfo; }
+    public Rigidbody Rigidbody { get => _rigidbody; }
 }


### PR DESCRIPTION
To test, just go to the berry ScriptableObject and change the new AttractionRadius property to something larger than 0.

+ Implemented ItemAttractor.cs and added to player GameObject.
+ Added AttractionRadius setting to ItemBase so item ScriptableObjects can set how close you must be for the item to start being attracted.
+ Added HasRoomForItem() overloaded function to InventoryBase to be able to check if an inventory has room for an item stack without actually trying to add it.

+ Fixed InventoryBase causing Unity warning ""Serialization depth limit 10 exceeded at 'Player::InventoryBase._overflowTo'. There may be an object composition cycle in one or more of your serialized classes."