### PR TITLE
Jelly Level Affects Number of Jellydew Produced

### DIFF
--- a/Assets/Prefabs/Jellies/Base_Jelly.prefab
+++ b/Assets/Prefabs/Jellies/Base_Jelly.prefab
@@ -196,6 +196,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   <jellyType>k__BackingField: 0
+  <NumOfDewSpawnedAtLevel>k__BackingField: 01000000
+  <RequiredExpForNextLevel>k__BackingField:
+  - 10
   <MaxFoodSaturation>k__BackingField: 100
   _minFoodSaturation: 20
   _foodSaturationInterval: 10
@@ -218,7 +221,6 @@ MonoBehaviour:
   _durationOfJump: 1.38
   _totalJumpHeight: 0.76
   _stateMachine: {fileID: 7924440530794558401}
-  _wanderEnter: {fileID: 11400000, guid: 95b03d51f3856b845bd4d3427e16ba2f, type: 2}
   _wanderExit: {fileID: 11400000, guid: 4bf60e81b010f214ab34282889a31737, type: 2}
 --- !u!1 &421980575205785031
 GameObject:

--- a/Assets/Prefabs/Jellies/Tumble.prefab
+++ b/Assets/Prefabs/Jellies/Tumble.prefab
@@ -207,6 +207,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _dewPrefab: {fileID: 2916422275461499499, guid: c4d143484380c78428d84c668b9d4ef6,
     type: 3}
+  minXSpawnRange: -5
+  maxXSpawnRange: 5
 --- !u!4 &711068664972694185 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 1106465352066037874, guid: 33c867d60e0514d40b5d18506242c367,

--- a/Assets/Scripts/Jellies/DewInstantiate.cs
+++ b/Assets/Scripts/Jellies/DewInstantiate.cs
@@ -6,9 +6,16 @@ public class DewInstantiate : MonoBehaviour
 {
     [SerializeField]
     private GameObject _dewPrefab;
+
+    [SerializeField]
+    private float minXSpawnRange = 1f;
+
+    [SerializeField]
+    private float maxXSpawnRange = 2f;
     
-    public void DewSpawn()
+    public void DewSpawn(int amount)
     {
-        Instantiate(_dewPrefab, transform.position + (transform.right * 1), transform.rotation);
+        for(int i = 0; i < amount; i++)
+            Instantiate(_dewPrefab, transform.position + (transform.right * Random.Range(minXSpawnRange, maxXSpawnRange)), transform.rotation);
     }
 }

--- a/Assets/Scripts/Jellies/Feeding.cs
+++ b/Assets/Scripts/Jellies/Feeding.cs
@@ -21,10 +21,13 @@ namespace Jellies
         private Parameters _parameters;
 
         private DewInstantiate _dew;
+
+        private SlimeExperience _slimeExp;
         private void Awake()
         {
             _parameters = GetComponent<Parameters>();
             _dew = GetComponent<DewInstantiate>();
+            _slimeExp = GetComponent<SlimeExperience>();
         }
 
         /// <summary>
@@ -44,8 +47,20 @@ namespace Jellies
             InventoryBase hotBar = InventoryScene.Instance.HotBar;
             if (hotBar.TrySubtractItemAmount(_berryItem, 1))
             {
-                FeedJelly(_berryItem.SaturationValue);  
-                _dew.DewSpawn();
+                FeedJelly(_berryItem.SaturationValue);
+
+                // Used to handle if the array is empty or outside of range for the slimes current level
+                try
+                {
+                    _dew.DewSpawn(_parameters.NumOfDewSpawnedAtLevel[_slimeExp.LevelNum - 1]);
+                } catch (System.IndexOutOfRangeException)
+                {
+                    // Uses the highest level requirement if the slimes current level is outside of range
+                    Debug.LogWarning("Property value \"NumOfDewSpawnedAtLevel\" array is either empty or outside of range for level num." +
+                        "Using highest level requirement (" + _parameters.NumOfDewSpawnedAtLevel[_parameters.NumOfDewSpawnedAtLevel.Length - 1] +
+                        ")");
+                    _dew.DewSpawn(_parameters.NumOfDewSpawnedAtLevel[_parameters.NumOfDewSpawnedAtLevel.Length - 1]);
+                }
             }
         }
     }

--- a/Assets/Scripts/Jellies/Parameters.cs
+++ b/Assets/Scripts/Jellies/Parameters.cs
@@ -26,7 +26,29 @@ namespace Jellies
         /// </summary>
         [Tooltip("What type of jelly is it.")]
         [field: SerializeField]
-        public JellyType jellyType 
+        public JellyType jellyType
+        {
+            get;
+            private set;
+        }
+
+        /// <summary>
+        /// The number of dew spawned per interaction.
+        /// </summary>
+        [Tooltip("The number of dew spawned per interaction. Index 0 is assumed to be level 1, index 1 level 2 and so on.")]
+        [field: SerializeField]
+        public int[] NumOfDewSpawnedAtLevel
+        {
+            get;
+            private set;
+        }
+
+        /// <summary>
+        /// The required experience per level
+        /// </summary>
+        [Tooltip("The required experience per level. Index 0 is assumed to be level 1, index 1 level 2 and so on.")]
+        [field: SerializeField]
+        public float[] RequiredExpForNextLevel
         {
             get;
             private set;

--- a/Assets/Scripts/Jellies/SlimeExperience.cs
+++ b/Assets/Scripts/Jellies/SlimeExperience.cs
@@ -2,6 +2,8 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using UnityEngine;
+using Jellies;
+
 ///<summary>
 /// Script: SlimeExperience.cs
 /// Author: Michael Spangenberg (m_spangenberg)
@@ -14,6 +16,7 @@ using UnityEngine;
 /// </summary>
 public class SlimeExperience : MonoBehaviour
 {
+    private Parameters _parameters;
     [Tooltip("The max level of the jelly")]
     [SerializeField]
     private int _maxLevel;
@@ -51,6 +54,18 @@ public class SlimeExperience : MonoBehaviour
     
     private string _previousEXPsource = "";
 
+    public int LevelNum
+    {
+        get => _levelNum;
+    }
+
+    private void Awake()
+    {
+        _parameters = GetComponent<Parameters>();
+        
+        _expThreshold = _parameters.RequiredExpForNextLevel.Length > 0 ? _parameters.RequiredExpForNextLevel[_levelNum] : _expThreshold;
+    }
+
     ///<summary>
     /// Timer that resets _consectuctiveInteractionCounter after EXP has not been gained in a while
     /// </summary>
@@ -79,12 +94,28 @@ public class SlimeExperience : MonoBehaviour
         float _extraEXP = _currentEXP - _expThreshold; //The extra EXP after a level up
         if(_levelNum < _maxLevel)
         {
-            _levelNum++; 
+            _levelNum++;
+
+            // Used to handle if the array is empty or outside of range for the slimes current level
+            try
+            {
+                _expThreshold = _parameters.RequiredExpForNextLevel[_levelNum - 1];
+            } catch (System.IndexOutOfRangeException)
+            {
+                // Uses the highest level requirement if the slimes current level is outside of range
+                Debug.LogWarning("Property value \"RequiredExpForNextLevel\" array is either empty or outside of range for level num. " +
+                    "Using highest level requirement (" + _parameters.RequiredExpForNextLevel[_parameters.RequiredExpForNextLevel.Length - 1] + 
+                    ")");
+                _expThreshold = _parameters.RequiredExpForNextLevel[_parameters.RequiredExpForNextLevel.Length - 1];
+            }
+
+            // Placeholder for notifying if the player has reached another level
+            Debug.Log("Your jelly has reached level " + _levelNum + "!");
         }
         
         _currentEXP = _extraEXP;
         _expThreshold *= _expMultiplier; 
-        _expToNextLevel = GetEXPtoNextLevel(); 
+        _expToNextLevel = GetEXPtoNextLevel();
     }
     /// <summary>
     /// Calculates the EXP that the jelly needs in order to get to the next level


### PR DESCRIPTION
Modified the DewInstantiate.cs script to add more than one dew depending on the value passed to the amount variable. Added two arrays to the Parameter.cs file for spawning more dew at the specific level and for analyzing the experience required to reach the next level. Added exception handling for if the slimes level is outside of range of the two arrays.