### PR TITLE
Improved Jelly movement

### DIFF
--- a/Assets/Art/Materials/Jellies/Prototype Eye Color.mat
+++ b/Assets/Art/Materials/Jellies/Prototype Eye Color.mat
@@ -1,0 +1,126 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &-3673976552730976652
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 5
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Prototype Eye Color
+  m_Shader: {fileID: 4800000, guid: 933532a4fcc9baf4fa0491de14d08ed7, type: 3}
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap:
+    RenderType: Opaque
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BaseMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SpecGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_Lightmaps:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_LightmapsInd:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_ShadowMasks:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _AlphaClip: 0
+    - _Blend: 0
+    - _BumpScale: 1
+    - _ClearCoatMask: 0
+    - _ClearCoatSmoothness: 0
+    - _Cull: 2
+    - _Cutoff: 0.5
+    - _DetailAlbedoMapScale: 1
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _EnvironmentReflections: 1
+    - _GlossMapScale: 0
+    - _Glossiness: 0
+    - _GlossyReflections: 0
+    - _Metallic: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.005
+    - _QueueOffset: 0
+    - _ReceiveShadows: 1
+    - _Smoothness: 0.5
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _Surface: 0
+    - _WorkflowMode: 1
+    - _ZWrite: 1
+    m_Colors:
+    - _BaseColor: {r: 0, g: 0.16444233, b: 0.5566038, a: 1}
+    - _Color: {r: 0, g: 0.1644423, b: 0.5566037, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
+  m_BuildTextureStacks: []

--- a/Assets/Art/Materials/Jellies/Prototype Eye Color.mat.meta
+++ b/Assets/Art/Materials/Jellies/Prototype Eye Color.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7ec381769ee13d946924993061755d00
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Art/Materials/Jellies/Prototype Mouth Color.mat
+++ b/Assets/Art/Materials/Jellies/Prototype Mouth Color.mat
@@ -1,0 +1,126 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &-3673976552730976652
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 5
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Prototype Mouth Color
+  m_Shader: {fileID: 4800000, guid: 933532a4fcc9baf4fa0491de14d08ed7, type: 3}
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap:
+    RenderType: Opaque
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BaseMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SpecGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_Lightmaps:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_LightmapsInd:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_ShadowMasks:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _AlphaClip: 0
+    - _Blend: 0
+    - _BumpScale: 1
+    - _ClearCoatMask: 0
+    - _ClearCoatSmoothness: 0
+    - _Cull: 2
+    - _Cutoff: 0.5
+    - _DetailAlbedoMapScale: 1
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _EnvironmentReflections: 1
+    - _GlossMapScale: 0
+    - _Glossiness: 0
+    - _GlossyReflections: 0
+    - _Metallic: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.005
+    - _QueueOffset: 0
+    - _ReceiveShadows: 1
+    - _Smoothness: 0.5
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _Surface: 0
+    - _WorkflowMode: 1
+    - _ZWrite: 1
+    m_Colors:
+    - _BaseColor: {r: 0.5568628, g: 0.1644423, b: 0, a: 1}
+    - _Color: {r: 0.5568628, g: 0.16444227, b: 0, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
+  m_BuildTextureStacks: []

--- a/Assets/Art/Materials/Jellies/Prototype Mouth Color.mat.meta
+++ b/Assets/Art/Materials/Jellies/Prototype Mouth Color.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: dce3284cbbbcfa2429f4f832ca5cd3b7
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Art/Textures/Jellies/Jelly_LeftBlush.png.meta
+++ b/Assets/Art/Textures/Jellies/Jelly_LeftBlush.png.meta
@@ -107,7 +107,7 @@ TextureImporter:
     outline: []
     physicsShape: []
     bones: []
-    spriteID: 
+    spriteID: 5e97eb03825dee720800000000000000
     internalID: 0
     vertices: []
     indices: 

--- a/Assets/Prefabs/Jellies/Tumble.prefab
+++ b/Assets/Prefabs/Jellies/Tumble.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &5236578732387563387
+--- !u!1 &356964902
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8,10 +8,466 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 859912623292058824}
-  - component: {fileID: 4121434137125918320}
-  - component: {fileID: 2250681428267076918}
-  - component: {fileID: 3549063758018540129}
+  - component: {fileID: 356964903}
+  m_Layer: 3
+  m_Name: Face
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &356964903
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 356964902}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.5}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 442113941}
+  - {fileID: 1411579066}
+  - {fileID: 1074414881}
+  m_Father: {fileID: 8730205451980050505}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &442113940
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 442113941}
+  - component: {fileID: 442113944}
+  - component: {fileID: 442113943}
+  - component: {fileID: 442113942}
+  m_Layer: 3
+  m_Name: Left Eye
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &442113941
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 442113940}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.24, y: 0.2, z: -0.03}
+  m_LocalScale: {x: 0.2, y: 0.2, z: 0.2}
+  m_ConstrainProportionsScale: 1
+  m_Children: []
+  m_Father: {fileID: 356964903}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &442113944
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 442113940}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &442113943
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 442113940}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 7ec381769ee13d946924993061755d00, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!135 &442113942
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 442113940}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &625831798
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 625831799}
+  - component: {fileID: 625831802}
+  - component: {fileID: 625831801}
+  - component: {fileID: 625831800}
+  m_Layer: 3
+  m_Name: Cube (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &625831799
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 625831798}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.25999832, y: -0.16, z: 0}
+  m_LocalScale: {x: 0.1, y: 0.1, z: 0.05}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1074414881}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &625831802
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 625831798}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &625831801
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 625831798}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: dce3284cbbbcfa2429f4f832ca5cd3b7, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &625831800
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 625831798}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &890512661
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 890512662}
+  - component: {fileID: 890512665}
+  - component: {fileID: 890512664}
+  - component: {fileID: 890512663}
+  m_Layer: 3
+  m_Name: Cube (2)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &890512662
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 890512661}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0.25999832, y: -0.16, z: 0}
+  m_LocalScale: {x: 0.1, y: 0.1, z: 0.05}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1074414881}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &890512665
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 890512661}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &890512664
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 890512661}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: dce3284cbbbcfa2429f4f832ca5cd3b7, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &890512663
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 890512661}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &1074414880
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1074414881}
+  m_Layer: 3
+  m_Name: Mouth
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1074414881
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1074414880}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8037052401110168521}
+  - {fileID: 625831799}
+  - {fileID: 890512662}
+  m_Father: {fileID: 356964903}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1411579065
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1411579066}
+  - component: {fileID: 1411579069}
+  - component: {fileID: 1411579068}
+  - component: {fileID: 1411579067}
+  m_Layer: 3
+  m_Name: Right Eye
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1411579066
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1411579065}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.24, y: 0.2, z: -0.03}
+  m_LocalScale: {x: 0.2, y: 0.2, z: 0.2}
+  m_ConstrainProportionsScale: 1
+  m_Children: []
+  m_Father: {fileID: 356964903}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &1411579069
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1411579065}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &1411579068
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1411579065}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 7ec381769ee13d946924993061755d00, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!135 &1411579067
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1411579065}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &1522185516
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1522185517}
+  - component: {fileID: 1522185520}
+  - component: {fileID: 1522185519}
+  - component: {fileID: 1522185518}
   m_Layer: 0
   m_Name: Cube
   m_TagString: Untagged
@@ -19,13 +475,13 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &859912623292058824
+--- !u!4 &1522185517
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5236578732387563387}
+  m_GameObject: {fileID: 1522185516}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
@@ -34,21 +490,21 @@ Transform:
   m_Father: {fileID: 711068664972694185}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!33 &4121434137125918320
+--- !u!33 &1522185520
 MeshFilter:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5236578732387563387}
+  m_GameObject: {fileID: 1522185516}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!23 &2250681428267076918
+--- !u!23 &1522185519
 MeshRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5236578732387563387}
+  m_GameObject: {fileID: 1522185516}
   m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
@@ -84,13 +540,110 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!65 &3549063758018540129
+--- !u!65 &1522185518
 BoxCollider:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5236578732387563387}
+  m_GameObject: {fileID: 1522185516}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &8635610933285087122
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8037052401110168521}
+  - component: {fileID: 7535332808312375476}
+  - component: {fileID: 4802764778097310712}
+  - component: {fileID: 7302596716891891442}
+  m_Layer: 3
+  m_Name: Cube
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8037052401110168521
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8635610933285087122}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: -0.258, z: 0}
+  m_LocalScale: {x: 0.5, y: 0.1, z: 0.05}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1074414881}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &7535332808312375476
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8635610933285087122}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &4802764778097310712
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8635610933285087122}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: dce3284cbbbcfa2429f4f832ca5cd3b7, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &7302596716891891442
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8635610933285087122}
   m_Material: {fileID: 0}
   m_IsTrigger: 0
   m_Enabled: 1
@@ -107,7 +660,27 @@ PrefabInstance:
     - target: {fileID: 94955809726303427, guid: 33c867d60e0514d40b5d18506242c367,
         type: 3}
       propertyPath: m_Name
-      value: Tumble
+      value: Tumble (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4401181319817377567, guid: 33c867d60e0514d40b5d18506242c367,
+        type: 3}
+      propertyPath: _wandDist
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4401181319817377567, guid: 33c867d60e0514d40b5d18506242c367,
+        type: 3}
+      propertyPath: _wandRange
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4706789909918235678, guid: 33c867d60e0514d40b5d18506242c367,
+        type: 3}
+      propertyPath: m_Height
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4706789909918235678, guid: 33c867d60e0514d40b5d18506242c367,
+        type: 3}
+      propertyPath: m_BaseOffset
+      value: 0.485
       objectReference: {fileID: 0}
     - target: {fileID: 4714310058802045046, guid: 33c867d60e0514d40b5d18506242c367,
         type: 3}
@@ -120,10 +693,27 @@ PrefabInstance:
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 5170292628604333891, guid: 33c867d60e0514d40b5d18506242c367,
+        type: 3}
+      propertyPath: _wanderEnter
+      value: 
+      objectReference: {fileID: 11400000, guid: 95b03d51f3856b845bd4d3427e16ba2f,
+        type: 2}
+    - target: {fileID: 5170292628604333891, guid: 33c867d60e0514d40b5d18506242c367,
+        type: 3}
+      propertyPath: _wanderUpdate
+      value: 
+      objectReference: {fileID: 11400000, guid: 99009a4ad11ac6d4da17be349170c3d0,
+        type: 2}
     - target: {fileID: 6897571014077337869, guid: 33c867d60e0514d40b5d18506242c367,
         type: 3}
       propertyPath: <jellyType>k__BackingField
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8381243061877071939, guid: 33c867d60e0514d40b5d18506242c367,
+        type: 3}
+      propertyPath: m_Constraints
+      value: 80
       objectReference: {fileID: 0}
     - target: {fileID: 9197237557971434130, guid: 33c867d60e0514d40b5d18506242c367,
         type: 3}
@@ -133,17 +723,17 @@ PrefabInstance:
     - target: {fileID: 9197237557971434130, guid: 33c867d60e0514d40b5d18506242c367,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -4.91
+      value: -33.71
       objectReference: {fileID: 0}
     - target: {fileID: 9197237557971434130, guid: 33c867d60e0514d40b5d18506242c367,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 2.71
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 9197237557971434130, guid: 33c867d60e0514d40b5d18506242c367,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -0.03
+      value: -11.88
       objectReference: {fileID: 0}
     - target: {fileID: 9197237557971434130, guid: 33c867d60e0514d40b5d18506242c367,
         type: 3}
@@ -153,17 +743,17 @@ PrefabInstance:
     - target: {fileID: 9197237557971434130, guid: 33c867d60e0514d40b5d18506242c367,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 9197237557971434130, guid: 33c867d60e0514d40b5d18506242c367,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 9197237557971434130, guid: 33c867d60e0514d40b5d18506242c367,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 9197237557971434130, guid: 33c867d60e0514d40b5d18506242c367,
         type: 3}
@@ -212,6 +802,12 @@ MonoBehaviour:
 --- !u!4 &711068664972694185 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 1106465352066037874, guid: 33c867d60e0514d40b5d18506242c367,
+    type: 3}
+  m_PrefabInstance: {fileID: 469725999948868315}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &8730205451980050505 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 9197237557971434130, guid: 33c867d60e0514d40b5d18506242c367,
     type: 3}
   m_PrefabInstance: {fileID: 469725999948868315}
   m_PrefabAsset: {fileID: 0}

--- a/Assets/Scenes/Debug.unity
+++ b/Assets/Scenes/Debug.unity
@@ -4950,6 +4950,7 @@ Transform:
   - {fileID: 1964190753}
   - {fileID: 1732815354}
   - {fileID: 1318948336}
+  - {fileID: 1110449162}
   m_Father: {fileID: 0}
   m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -5053,6 +5054,16 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: Tumble
+      objectReference: {fileID: 0}
+    - target: {fileID: 8274490643243616920, guid: 68eea3fc79eb3494aaa9f78ea6a3f356,
+        type: 3}
+      propertyPath: m_Constraints
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 8274490643243616920, guid: 68eea3fc79eb3494aaa9f78ea6a3f356,
+        type: 3}
+      propertyPath: m_IsKinematic
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8730205451980050505, guid: 68eea3fc79eb3494aaa9f78ea6a3f356,
         type: 3}
@@ -6413,7 +6424,7 @@ GameObject:
   - component: {fileID: 672370341}
   - component: {fileID: 672370340}
   - component: {fileID: 672370339}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: Plane
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -9244,6 +9255,12 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1107892311}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1110449162 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8730205451980050505, guid: 68eea3fc79eb3494aaa9f78ea6a3f356,
+    type: 3}
+  m_PrefabInstance: {fileID: 1377075913}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1111485940
 GameObject:
   m_ObjectHideFlags: 0
@@ -11445,6 +11462,75 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1356123055}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1001 &1377075913
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 518855514}
+    m_Modifications:
+    - target: {fileID: 564520608544531992, guid: 68eea3fc79eb3494aaa9f78ea6a3f356,
+        type: 3}
+      propertyPath: m_Name
+      value: Tumble (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8730205451980050505, guid: 68eea3fc79eb3494aaa9f78ea6a3f356,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8730205451980050505, guid: 68eea3fc79eb3494aaa9f78ea6a3f356,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -33.71
+      objectReference: {fileID: 0}
+    - target: {fileID: 8730205451980050505, guid: 68eea3fc79eb3494aaa9f78ea6a3f356,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8730205451980050505, guid: 68eea3fc79eb3494aaa9f78ea6a3f356,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -11.88
+      objectReference: {fileID: 0}
+    - target: {fileID: 8730205451980050505, guid: 68eea3fc79eb3494aaa9f78ea6a3f356,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8730205451980050505, guid: 68eea3fc79eb3494aaa9f78ea6a3f356,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8730205451980050505, guid: 68eea3fc79eb3494aaa9f78ea6a3f356,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8730205451980050505, guid: 68eea3fc79eb3494aaa9f78ea6a3f356,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8730205451980050505, guid: 68eea3fc79eb3494aaa9f78ea6a3f356,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8730205451980050505, guid: 68eea3fc79eb3494aaa9f78ea6a3f356,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8730205451980050505, guid: 68eea3fc79eb3494aaa9f78ea6a3f356,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 68eea3fc79eb3494aaa9f78ea6a3f356, type: 3}
 --- !u!1 &1378078682
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/GameEventScriptableObject.cs
+++ b/Assets/Scripts/GameEventScriptableObject.cs
@@ -169,6 +169,7 @@ public class GameEventScriptableObject : ScriptableObject
             {
                 (MonoBehaviour selectiveFor, GameEventScriptableObject gameEvent, System.Action action) 
                     = selectiveEventsAndResponses[i];
+
                 gameEvent.AddOnRaise(action, selectiveFor);
             }
         }

--- a/Assets/Scripts/Jellies/Hopping.cs
+++ b/Assets/Scripts/Jellies/Hopping.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using UnityEngine;
+using UnityEngine.AI;
 
 public class Hopping : MonoBehaviour
 {
@@ -9,18 +10,41 @@ public class Hopping : MonoBehaviour
     [SerializeField, Tooltip("We manipulate local position of the model itself so we need a reference to just the model")]
     private GameObject _model;
 
-    [SerializeField, Tooltip("The amount of time taken for jump to cpmplete")]
-    private float _durationOfJump;
 
-    [SerializeField, Tooltip("Total Height in Unity units for the Jelly to hop")]
-    private float _totalJumpHeight;
+    [Header("Hopping Parammeters")]
+
+    [SerializeField, Min(0), Tooltip("Min height in Unity units of the Jelly's hop.")]
+    private float _minHopHeight = 0.30f;
+
+    [SerializeField, Min(0), Tooltip("Max height in Unity units of the Jelly's hop.")]
+    private float _maxHopHeight = 0.76f;
+
+    [SerializeField, Min(0), Tooltip("Max time (in seconds) between the Jelly's hops.")]
+    private float _minTimeBetweenHops = 0.5f;
+
+    [SerializeField, Min(0), Tooltip("Min height in Unity units of the Jelly's hop.")]
+    private float _maxTimeBetweenHops = 1f;
+
 
     [SerializeField]
     private JellyStateMachine _stateMachine;
     [SerializeField]
+    private GameEventScriptableObject _wanderEnter;
+    [SerializeField]
+    private GameEventScriptableObject _wanderUpdate;
+    [SerializeField]
     private GameEventScriptableObject _wanderExit;
 
-    private bool _alreadyHopping;
+
+    private NavMeshAgent _navAgent;
+    private Rigidbody _rigidbody;
+
+    private bool _isGrounded = true;
+
+    private float _hopTimer;
+    private float _groundedTimer;
+
+    private bool _hopRoutineIsRunning;
 
     private bool _isFinished = true;
 
@@ -28,46 +52,116 @@ public class Hopping : MonoBehaviour
 
     private void Awake()
     {
-        _wandering.OnChangeDirection += SetIsFinished;
-        _gameEventResponses.SetSelectiveResponses(_stateMachine
-            , (_wanderExit, SetIsFinished));
+        //_wandering.OnChangeDirection += SetIsFinished;
+        _gameEventResponses.SetSelectiveResponses(_stateMachine,
+            (_wanderEnter, WanderEnter),
+            (_wanderUpdate, WanderUpdate),
+            (_wanderExit, WanderExit));
+
+        _navAgent = GetComponent<NavMeshAgent>();
+        _rigidbody = GetComponent<Rigidbody>();
     }
 
     private void OnEnable() => _gameEventResponses.Register();
     private void OnDisable() => _gameEventResponses.Unregister();
 
-    void Update()
+    public void WanderEnter()
     {
-        if (!_alreadyHopping && !_isFinished)
+        _isFinished = false;
+    }
+
+    public void WanderUpdate()
+    {
+        CheckIfGrounded();
+
+        _hopTimer -= Time.deltaTime;
+        if (!_hopRoutineIsRunning && _isGrounded && _hopTimer <= 0 && !_isFinished)
         {
-            StartCoroutine(PerformTheHop());            
+            StartCoroutine(StartHop());
+        }
+    }
+
+    public void WanderExit()
+    {
+        _isFinished = true;
+    }
+
+    private void CheckIfGrounded()
+    {
+        // If the jelly's vertical velocity is near zero, increment the groundedTimer.
+        if (_rigidbody.velocity.y > -0.1f && _rigidbody.velocity.y < 0.1f)
+        {
+            _groundedTimer += Time.deltaTime;
+        }
+        // If the jelly's vertical velocity is moving upward, then reset the grounded timer to 0f.
+        else if (_rigidbody.velocity.y >= 0.1f)
+        {
+            _isGrounded = false;
+            _groundedTimer = 0f;
+        }
+        
+        // If the jelly has been on the ground a short time, then set _isGrounded to true.
+        if (_groundedTimer >= 0.3f)
+        {
+            _isGrounded = true;
         }
     }
 
     private void SetIsFinished(bool newValue)
     {
-        _isFinished = newValue;
+        Debug.Log("Set: " +  newValue);
+        //_isFinished = newValue;
     }
 
-    private void SetIsFinished()
+    private IEnumerator StartHop()
     {
-        _isFinished = true;
-    }
+        _hopRoutineIsRunning = true;
 
-    private IEnumerator PerformTheHop()
-    {
-        _alreadyHopping = true;
-        Transform localTransform = _model.transform;
-        float trueHeight = _totalJumpHeight / Mathf.Pow(_durationOfJump / 2, 2); 
+        _rigidbody.isKinematic = false;
 
-        for (float i = 0; i < _durationOfJump; i += Time.deltaTime)
+        _navAgent.enabled = false;
+        _rigidbody.velocity += GetJumpVelocity();
+        _isGrounded = false;
+
+
+        // We put a quarter second on the timer, as this is being used to disable the code in OnCollisionEnter that detects when the jelly is back on the ground.
+        // This short delay is needed, as otherwise the OnCollisionEnter() function will instantly set the _isGrounded variable to true again before the jelly
+        // has a chance to jump off the ground.
+        _hopTimer = 0.1f;
+        while (!_isGrounded)
         {
-            Vector3 localPos = localTransform.localPosition;
-            localTransform.localPosition = new Vector3(localPos.x, i * trueHeight * (_durationOfJump - i), localPos.z);
             yield return null;
         }
 
-        _alreadyHopping = false;
+
+        // Reset the hop timer, as it will now be used to handle the delay between hops.
+        _hopTimer = Random.Range(_minTimeBetweenHops, _maxTimeBetweenHops);
+
+        _navAgent.enabled = true;
+        _rigidbody.isKinematic = true;
+
+        _hopRoutineIsRunning = false;
+    }
+
+
+    private Vector3 GetJumpVelocity()
+    {
+        // This formula (u*u = 2gS) is calculating the velocity needed to reach the specified jump height.        
+        // I derived it from this page at #2 under "Maximum height of a projectile": https://byjus.com/question-answer/how-do-you-determine-the-maximum-height-of-a-projectile/
+        // NOTE: I removed v squared and added (2gH) to both sides so u squared is by itself so we can now solve for it.
+        //       v squared is the final velocity, which is 0 since the jelly lands at the end of the jump.
+        //       u squared is the initial velocity we're solving for.
+        //       g is gravity
+        //       S is the distance traveled, which is our total jump height.
+        float minJumpVelocity = Mathf.Sqrt(2 * -(Physics.gravity.y) * _minHopHeight);
+        float maxJumpVelocity = Mathf.Sqrt(2 * -(Physics.gravity.y) * _maxHopHeight);
+
+        Vector3 jumpVelocity = transform.forward * _navAgent.speed;
+        jumpVelocity.y = Random.Range(minJumpVelocity, maxJumpVelocity);
+
+        //Debug.Log(jumpVelocity);
+
+        return jumpVelocity;
     }
 
 }

--- a/Assets/Scripts/Jellies/SlimeExperience.cs
+++ b/Assets/Scripts/Jellies/SlimeExperience.cs
@@ -40,17 +40,17 @@ public class SlimeExperience : MonoBehaviour
     private float _testEXPGain = 10f;
     [Tooltip("A variable for that when reached initiates EXP penalty formula")]
     [SerializeField]
-    private int _consectuctiveInteractionThreshold = 5;
-    [Tooltip("A variable that defines in seconds when to reset _consectuctiveInteractionCounter")]
+    private int _consecutiveInteractionThreshold = 5;
+    [Tooltip("A variable that defines in seconds when to reset _consecutiveInteractionCounter")]
     [SerializeField]
-    private float _consectuctiveInteractionTimer = 30f;
+    private float _consecutiveInteractionTimer = 30f;
     [Tooltip("A variable that determines how much penalty scales for interactions")]
     [SerializeField]
     private float _penaltyPercentage = 0.4f;
 
     private float _timeSinceLastInteraction = 0f;
 
-    private int _consectuctiveInteractionCounter = 0;
+    private int _consecutiveInteractionCounter = 0;
     
     private string _previousEXPsource = "";
 
@@ -67,7 +67,7 @@ public class SlimeExperience : MonoBehaviour
     }
 
     ///<summary>
-    /// Timer that resets _consectuctiveInteractionCounter after EXP has not been gained in a while
+    /// Timer that resets _consecutiveInteractionCounter after EXP has not been gained in a while
     /// </summary>
     void Update()
     {
@@ -79,11 +79,11 @@ public class SlimeExperience : MonoBehaviour
         #endif
 
         _timeSinceLastInteraction += Time.deltaTime;
-        if (_timeSinceLastInteraction >= _consectuctiveInteractionTimer) 
+        if (_timeSinceLastInteraction >= _consecutiveInteractionTimer) 
         {
             //Debug.Log("_consectuctiveInteractionCounter reset");
             _timeSinceLastInteraction = 0f;
-            _consectuctiveInteractionCounter = 0;
+            _consecutiveInteractionCounter = 0;
         }
     }
     ///<summary>
@@ -119,7 +119,7 @@ public class SlimeExperience : MonoBehaviour
     /// <summary>
     /// Adds additional EXP to the currentEXP
     /// If the EXP total reaches the EXP threshold, the level up function is called
-    /// When consecutive interactions are done more than the _consectuctiveInteractionThreshold allows
+    /// When consecutive interactions are done more than the _consecutiveInteractionThreshold allows
     /// for, the jelly will get an EXP penalty.
     /// parameter EXP: The EXP gained from the action
     /// parameter EXPsource: The source the EXP comes from
@@ -130,21 +130,22 @@ public class SlimeExperience : MonoBehaviour
 
         if (_previousEXPsource != EXPsource)
         {
-            _consectuctiveInteractionCounter = 0;
+            _consecutiveInteractionCounter = 0;
         }
         else 
         {
-            _consectuctiveInteractionCounter++;
+            _consecutiveInteractionCounter++;
         }
 
         _previousEXPsource = EXPsource;
         //Debug.Log("Source: " + EXPsource);
 
-        if (_consectuctiveInteractionCounter >= _consectuctiveInteractionThreshold) 
+        if (_consecutiveInteractionCounter >= _consecutiveInteractionThreshold) 
         {
-            float penalty = 1 / (1 + (_penaltyPercentage * (_consectuctiveInteractionCounter - _consectuctiveInteractionThreshold)));
+            float penalty = 1 / (1 + (_penaltyPercentage * (_consecutiveInteractionCounter - _consecutiveInteractionThreshold)));
             EXP *= penalty;
-            //Debug.Log("Consecutive Counter: " + _consectuctiveInteractionCounter + "| EXP Given: " + EXP);
+            //Debug.Log("Consecutive Counter: " + _consecutiveInteractionCounter + "| EXP Given: " + EXP);
+
             // In the future, add jelly annoyance reaction here to indicate EXP penalty to player.
         }
 

--- a/Assets/Scripts/Jellies/State Machine/Wandering.cs
+++ b/Assets/Scripts/Jellies/State Machine/Wandering.cs
@@ -65,7 +65,7 @@ public class Wandering : MonoBehaviour
     /// and either the jelly's doesn't have a path or the squared magnitude is 0, false otherwise. </returns>
     private bool NearDestination(float nearOffset)
     {
-        if (!_meshAgent.pathPending 
+        if (_meshAgent.enabled && !_meshAgent.pathPending 
             && _meshAgent.remainingDistance < Mathf.Min(_meshAgent.stoppingDistance, nearOffset) 
             && (!_meshAgent.hasPath || _meshAgent.velocity.sqrMagnitude == 0))
         {
@@ -88,7 +88,6 @@ public class Wandering : MonoBehaviour
         else 
         {
             // Create new destination for the jelly.
-
             Transform jellyTransform = transform;
             Vector3 wanderCenter = jellyTransform.position + (jellyTransform.forward * _wandDist);
             if (!CalcRandomWanderPoint(wanderCenter, _wandRange, out Vector3 calcPoint))

--- a/Assets/Scripts/Jellies/State Machine/Watching.cs
+++ b/Assets/Scripts/Jellies/State Machine/Watching.cs
@@ -15,6 +15,9 @@ public class Watching : MonoBehaviour
     private GameEventScriptableObject _exitWatching;
     [SerializeField, Range(0, 10), Tooltip("The distance the jelly watches the subject from")]
     private int _watchDistance;
+    [SerializeField, Range(1, 180), Tooltip("The speed at which the jelly rotates to face the player (in degrees per second).")]
+    private float _turnToFacePlayerSpeed = 60f;
+
 
     private Transform _player;
     private GameEventResponses _gameEventResponses = new();
@@ -34,8 +37,32 @@ public class Watching : MonoBehaviour
 
     private void UpdateWatching()
     {
-        _agent.stoppingDistance = _watchDistance;
-        _agent.SetDestination(_player.position);
+        if (_agent.enabled)
+        {
+            _agent.stoppingDistance = _watchDistance;
+            _agent.SetDestination(_player.position);
+        }
+
+        TurnToFacePoint(_player.position);
+    }
+
+    private void TurnToFacePoint(Vector3 position)
+    {
+        Quaternion q = Quaternion.LookRotation(position - _agent.transform.position);
+        Vector3 eulerAngles = q.eulerAngles;
+        
+        // Clear x and z rotations to 0 so the jelly doesn't tilt down and look at the player's feet.        
+        eulerAngles.x = eulerAngles.z = 0f;
+
+        // Calculate the rotation between the Jelly's direction and the direction the player is in.
+        eulerAngles.y = Mathf.Clamp(eulerAngles.y - _agent.transform.rotation.eulerAngles.y, 
+                                    -_turnToFacePlayerSpeed,
+                                    _turnToFacePlayerSpeed) * Time.deltaTime;
+
+        eulerAngles.y += _agent.transform.rotation.eulerAngles.y;
+        q.eulerAngles = eulerAngles;
+
+        _agent.transform.rotation = q;
     }
 
     private void ExitWatching()

--- a/Assets/Wwise/API/Runtime/Plugins/Windows/x86/DSP/AkSynthOne.dll.meta
+++ b/Assets/Wwise/API/Runtime/Plugins/Windows/x86/DSP/AkSynthOne.dll.meta
@@ -14,7 +14,7 @@ PluginImporter:
   - first:
       Any: 
     second:
-      enabled: 1
+      enabled: 0
       settings: {}
   - first:
       Editor: Editor

--- a/Assets/Wwise/API/Runtime/Plugins/Windows/x86/DSP/MasteringSuite.dll.meta
+++ b/Assets/Wwise/API/Runtime/Plugins/Windows/x86/DSP/MasteringSuite.dll.meta
@@ -14,7 +14,7 @@ PluginImporter:
   - first:
       Any: 
     second:
-      enabled: 1
+      enabled: 0
       settings: {}
   - first:
       Editor: Editor

--- a/Assets/Wwise/API/Runtime/Plugins/Windows/x86_64/DSP/AkSynthOne.dll.meta
+++ b/Assets/Wwise/API/Runtime/Plugins/Windows/x86_64/DSP/AkSynthOne.dll.meta
@@ -14,7 +14,7 @@ PluginImporter:
   - first:
       Any: 
     second:
-      enabled: 1
+      enabled: 0
       settings: {}
   - first:
       Editor: Editor

--- a/Assets/Wwise/API/Runtime/Plugins/Windows/x86_64/DSP/MasteringSuite.dll.meta
+++ b/Assets/Wwise/API/Runtime/Plugins/Windows/x86_64/DSP/MasteringSuite.dll.meta
@@ -14,7 +14,7 @@ PluginImporter:
   - first:
       Any: 
     second:
-      enabled: 1
+      enabled: 0
       settings: {}
   - first:
       Editor: Editor


### PR DESCRIPTION
+ Hopping script has min/max jump height settings so their movement feels a bit more natural now.
+ Added min/max delay settings to Hopping.cs so they don't always hop at the exact same interval.
+ Jelly hopping is now using the rigidbody, though it disables the navmeshAgent temporarily while hopping (otherwise he just stays glued to the ground when he should be hopping)
+ When you get close enough, the jelly turns to face you now. His rotation speed is configurable in the inspector on the Watching.cs script. I had it set way to slow at first, so first time I tested it he turned around really slow and creepy like this is a horror game or something. lol
+ Added a simple face on the jelly so its easier to see which way he's facing