### PR TITLE
Experiment nathan jelly preferences

### DIFF
--- a/Assets/Prefabs/Jellies/Base_Jelly.prefab
+++ b/Assets/Prefabs/Jellies/Base_Jelly.prefab
@@ -20,6 +20,7 @@ GameObject:
   - component: {fileID: 6897571014077337869}
   - component: {fileID: 5170292628604333891}
   - component: {fileID: 2800760254389377842}
+  - component: {fileID: 1774028502545570940}
   m_Layer: 3
   m_Name: Base_Jelly
   m_TagString: Untagged
@@ -129,7 +130,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 82b72aea51f8a3445980dd89248a65a3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _foodItemIdentity: {fileID: 0}
 --- !u!114 &4714310058802045046
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -237,6 +237,25 @@ MonoBehaviour:
     type: 3}
   minXSpawnRange: -5
   maxXSpawnRange: 5
+--- !u!114 &1774028502545570940
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 94955809726303427}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d24253333aaec43438c927b8095d9bc3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  preferenceRange: 5
+  <Sour>k__BackingField: 0
+  <Sweet>k__BackingField: 0
+  <Savory>k__BackingField: 0
+  <Salty>k__BackingField: 0
+  <Bitter>k__BackingField: 0
+  <Spicy>k__BackingField: 0
 --- !u!1 &421980575205785031
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/InteractionSystem/JellyInteractBase.cs
+++ b/Assets/Scripts/InteractionSystem/JellyInteractBase.cs
@@ -12,6 +12,8 @@ public class JellyInteractBase : InteractableWithUIMode
 
     private Parameters _jellyParams;
 
+    private FoodPreferences _foodPreferences;
+
     public Feeding Feeding { get; private set; }
 
 
@@ -19,6 +21,7 @@ public class JellyInteractBase : InteractableWithUIMode
     {
         _jellyParams = GetComponent<Parameters>();
         Feeding = GetComponent<Feeding>();
+        _foodPreferences = GetComponent<FoodPreferences>();
     }
 
     private void Update()
@@ -36,8 +39,17 @@ public class JellyInteractBase : InteractableWithUIMode
             case FoodItemIdentity food:
                 if(_jellyParams.FoodSaturation < _jellyParams.MaxFoodSaturation)
                 {
-                    Feeding.TryFeedJelly(food.SaturationValue);
-                    return true;
+                    int adjustedSaturation = _foodPreferences.GetAdjustedSaturation(food);
+                    if(adjustedSaturation < food.SaturationValue)
+                    {
+                        // Could replace with a way to decrease how much the Jelly likes the player 
+                        Debug.Log("The Jelly did not like that food");
+                    } else
+                    {
+                        // Could replace with a way to increase how much the Jelly likes the player
+                        Debug.Log("The jelly loved that food");
+                    }
+                    return Feeding.TryFeedJelly(adjustedSaturation);
                 }
                 return false;
 

--- a/Assets/Scripts/Jellies/Feeding.cs
+++ b/Assets/Scripts/Jellies/Feeding.cs
@@ -14,9 +14,6 @@ namespace Jellies
     /// </summary>
     public class Feeding : MonoBehaviour
     {
-        [SerializeField, Tooltip("Scriptable object representing" +
-        " the type of item to feed the jelly")]
-        private FoodItemIdentity _foodItemIdentity;
 
         private Parameters _parameters;
 
@@ -38,7 +35,7 @@ namespace Jellies
         /// Feeds jelly by increasing it's food saturation.
         /// </summary>
         /// <param name="amountToIncrease">Amount of food to feed by, is same as saturation.</param>
-        public bool TryFeedJelly(float amountToIncrease)
+        public bool TryFeedJelly(float saturation)
         {
             if (_parameters.FoodSaturation >= _parameters.MaxFoodSaturation)
             {
@@ -49,8 +46,7 @@ namespace Jellies
                 }
                 return false;
             }
-
-            _parameters.IncreaseFoodSaturation(amountToIncrease);
+            _parameters.IncreaseFoodSaturation(saturation);
 
             int index = Math.Min(_parameters.NumOfDewSpawnedAtLevel.Length - 1, _slimeExp.LevelNum - 1);
             _dew.DewSpawn(_parameters.NumOfDewSpawnedAtLevel[index]);
@@ -58,16 +54,7 @@ namespace Jellies
             return true;
         }
 
-        /// <summary>
-        /// Called by the jelly prefab's feed button.
-        /// </summary>
-        public void OnFeedButton()
-        {
-            if (Inventory.Instance.TrySubtractItemAmount(_foodItemIdentity, 1))
-            {
-                TryFeedJelly(_foodItemIdentity.SaturationValue);
-            }
-        }
+        
     }
 }
 

--- a/Assets/Scripts/Jellies/FoodPreferences.cs
+++ b/Assets/Scripts/Jellies/FoodPreferences.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Jellies
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public class FoodPreferences : MonoBehaviour
+    {
+        [SerializeField, Tooltip("The range preferences can have")]
+        private int preferenceRange;
+
+        [field: SerializeField, Tooltip("How sour is the food")]
+        public int Sour { get; private set; }
+        [field: SerializeField, Tooltip("How sweet is the food")]
+        public int Sweet { get; private set; }
+        [field: SerializeField, Tooltip("How savory is the food?")]
+        public int Savory { get; private set; }
+        [field: SerializeField, Tooltip("How salty is the food?")]
+        public int Salty { get; private set; }
+        [field: SerializeField, Tooltip("How bitter is the food?")]
+        public int Bitter { get; private set; }
+        [field: SerializeField, Tooltip("How spicy is the food?")]
+        public int Spicy { get; private set; }
+
+        private void Start()
+        {
+            List<int> preferences = new List<int>();
+            preferences.Add(Sour = UnityEngine.Random.Range(1, preferenceRange));
+            preferences.Add(Sweet = UnityEngine.Random.Range(1, preferenceRange));
+            preferences.Add(Savory = UnityEngine.Random.Range(1, preferenceRange));
+            preferences.Add(Salty = UnityEngine.Random.Range(1, preferenceRange));
+            preferences.Add(Bitter = UnityEngine.Random.Range(1, preferenceRange));
+            preferences.Add(Spicy = UnityEngine.Random.Range(1, preferenceRange));
+            preferences.Sort();
+            int multiplier = -1;
+            for (int i = 0; i < 3; i++)
+            {
+                int preference = UnityEngine.Random.Range(1, 6);
+                switch (preference)
+                {
+                    case 1: Sour *= multiplier; break;
+                    case 2: Sweet *= multiplier; break;
+                    case 3: Savory *= multiplier; break;
+                    case 4: Salty *= multiplier; break;
+                    case 5: Bitter *= multiplier; break;
+                    case 6: Spicy *= multiplier; break;
+                }
+            }
+        }
+
+        public int GetAdjustedSaturation(FoodItemIdentity food)
+        {
+            int sum = 0;
+            sum += Sour * food.Sour;
+            sum += Sweet * food.Sweet;
+            sum += Savory * food.Savory;
+            sum += Salty * food.Salty;
+            sum += Bitter * food.Bitter;
+            sum += Bitter * food.Bitter;
+            if (sum < 0)
+            {
+                sum = 1;
+            }
+            return sum;
+        }
+
+    }
+}

--- a/Assets/Scripts/Jellies/FoodPreferences.cs
+++ b/Assets/Scripts/Jellies/FoodPreferences.cs
@@ -60,7 +60,7 @@ namespace Jellies
             sum += Salty * food.Salty;
             sum += Bitter * food.Bitter;
             sum += Bitter * food.Bitter;
-            if (sum < 0)
+            if (sum < 1)
             {
                 sum = 1;
             }

--- a/Assets/Scripts/Jellies/FoodPreferences.cs.meta
+++ b/Assets/Scripts/Jellies/FoodPreferences.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d24253333aaec43438c927b8095d9bc3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
- Jellies have randomly generated preferences
- The saturation value provided by food is directly impacted by their preferences.
- Mistakes and bigger mistakes have been changed to have a value of zero for all flavors. This prevents Jellies from potentially liking the food.